### PR TITLE
Fix the name of the onFileUpload property/function to onUploadFile

### DIFF
--- a/ReactLensWriter.js
+++ b/ReactLensWriter.js
@@ -23,8 +23,8 @@ var ReactLensWriter = React.createClass({
     this.props.onSave(xml, cb);
   },
 
-  _onFileUpload: function(file, cb) {
-    this.props.onFileUpload(file, cb);
+  _onUploadFile: function(file, cb) {
+    this.props.onUploadFile(file, cb);
   },
 
   getContent: function() {
@@ -52,7 +52,7 @@ var ReactLensWriter = React.createClass({
     this.writer = Component.mount($$(LensWriter, {
       doc: doc,
       onSave: this._onSave,
-      onFileUpload: this._onFileUpload
+      onUploadFile: this._onUploadFile
     }), el);
   },
 


### PR DESCRIPTION
Right now, the prop is not correctly named, so it doesn't get used here: https://github.com/substance/lens/blob/eb0891c2907f3255cba37300b417469ad8f15e79/LensController.js#L110
