### PR TITLE
WIP: Font awesome fix for npm > 3

### DIFF
--- a/styles/_lens.scss
+++ b/styles/_lens.scss
@@ -1,4 +1,4 @@
-$fa-font-path:  "./fonts" !default;
+$fa-font-path:  "~font-awesome/fonts" !default;
 @import 'font-awesome/scss/font-awesome';
 
 // Substance base styles
@@ -13,7 +13,7 @@ $fa-font-path:  "./fonts" !default;
 @import './components/_add-bib-items-panel';
 @import './components/_bib-item';
 @import './components/_cite-panel';
-@import './packages/citations/citation.scss';
+@import '../packages/citations/citation';
 
 // Most layouting is now done using SplitPane
 %lens {

--- a/styles/_lens.scss
+++ b/styles/_lens.scss
@@ -1,12 +1,12 @@
 $fa-font-path:  "./fonts" !default;
-@import '../node_modules/font-awesome/scss/font-awesome';
+@import 'font-awesome/scss/font-awesome';
 
 // Substance base styles
-@import '../node_modules/substance/styles/base/index';
+@import 'substance/styles/base/index';
 
 // Substance modules
-@import '../node_modules/substance/styles/components/_all';
-@import '../node_modules/substance/packages/_all';
+@import 'substance/styles/components/_all';
+@import 'substance/packages/_all';
 
 // Lens stuff
 @import './components/_bib-items-panel';


### PR DESCRIPTION
This: https://github.com/substance/lens/blob/master/styles/_lens.scss#L2 doesn't work anymore in Npm > 3. Npm > 3 flattens the dependency tree, and that means that if the `lens` module is installed as a dependency, then it will no longer have a nested `node_modules` folder with its dependencies, but those dependencies will instead be installed at the project's root `node_modules`.

I'm not exactly sure what the absolute best fix is, so this is a start. There is currently one Webpack specific fix at: https://github.com/jure/lens/blob/16928130bc84902482ca16afb1e558b5bd76ec39/styles/_lens.scss#L1
so this one will have to be changed to a generic solution for sure.

I imagine you do want to fix this, but if you don't want to support npm > 3, I suggest you make that clear in your `package.json`, by specifying a version in the engines. 
