### PR TITLE
Correct the citation.scss file path.

### DIFF
--- a/styles/_lens.scss
+++ b/styles/_lens.scss
@@ -13,7 +13,7 @@ $fa-font-path:  "./fonts" !default;
 @import './components/_add-bib-items-panel';
 @import './components/_bib-item';
 @import './components/_cite-panel';
-@import './packages/citations/citation.scss';
+@import '../packages/citations/citation.scss';
 
 // Most layouting is now done using SplitPane
 %lens {


### PR DESCRIPTION
The citation.scss file is one folder up, and then in `packages/citations`, not in the same folder as _lens.scss. I still don't know why this works if I just use `npm run start` in your project, but it definitely breaks for me: 

```
    @import './packages/citations/citation.scss';
    ^
          File to import not found or unreadable: ./packages/citations/citation.scss
```
